### PR TITLE
Set the default uuid value to use gen_random_uuid

### DIFF
--- a/src/pgsql/pgsql-ddl.lisp
+++ b/src/pgsql/pgsql-ddl.lisp
@@ -144,7 +144,7 @@
   '((:null              . "NULL")
     (:current-date      . "CURRENT_DATE")
     (:current-timestamp . "CURRENT_TIMESTAMP")
-    (:generate-uuid     . "uuid_generate_v4()"))
+    (:generate-uuid     . "gen_random_uuid()"))
   "Common normalized default values and their PostgreSQL spelling.")
 
 (defmethod format-default-value ((column column) &key (stream nil))


### PR DESCRIPTION
pgloader uses `uuid_generate_v4` which requires loading the `uuid-ossp` extension into the database. Since version 13, Postgres has supported `gen_random_uuid`, which does not. This just changes the default value for UUIDs to `gen_random_uuid` instead of `uuid_generate_v4`.